### PR TITLE
chore: cleanup Norwegian Municipalities

### DIFF
--- a/Norwegian_Municipalities.yml
+++ b/Norwegian_Municipalities.yml
@@ -2,35 +2,16 @@ title: Norwegian Municipalities
 description: Norwegian municipalities, including local government websites that provide information on public services, administration, and community resources.
 uuid: 4cff6f14-cfcd-48ea-b8f6-be2e7aa75800
 domains:
-    - alver.kommune.no
-    - bjornafjorden.kommune.no
-    - faerder.kommune.no
-    - fjaler.kommune.no
-    - fjord.kommune.no
-    - gildeskal.kommune.no
-    - gulen.kommune.no
-    - heim.kommune.no
-    - hustadvika.kommune.no
-    - hyllestad.kommune.no
-    - indrefosen.kommune.no
-    - io.kommune.no
-    - lillestrom.kommune.no
-    - lom.kommune.no
-    - midt-telemark.kommune.no
-    - naroysund.kommune.no
-    - nesbyen.kommune.no
-    - suldal.kommune.no
-    - sunnfjord.kommune.no
-    - ullensvang.kommune.no
-    - vestnes.kommune.no
     - aal.kommune.no
     - afjord.kommune.no
     - alesund.kommune.no
     - alstahaug.kommune.no
     - alta.kommune.no
     - alvdal.kommune.no
+    - alver.kommune.no
     - amli.kommune.no
     - amot.kommune.no
+    - andoy.kommune.no
     - ardal.kommune.no
     - aremark.kommune.no
     - arendal.kommune.no
@@ -58,7 +39,7 @@ domains:
     - bindal.kommune.no
     - birkenes.kommune.no
     - bjerkreim.kommune.no
-    - bjugn.kommune.no
+    - bjornafjorden.kommune.no
     - bodo.kommune.no
     - boe.kommune.no
     - bokn.kommune.no
@@ -83,11 +64,13 @@ domains:
     - etne.kommune.no
     - etnedal.kommune.no
     - evenes.kommune.no
+    - faerder.kommune.no
     - farsund.kommune.no
     - fauske.kommune.no
     - fedje.kommune.no
-    - finnoy.kommune.no
     - fitjar.kommune.no
+    - fjaler.kommune.no
+    - fjord.kommune.no
     - flaa.kommune.no
     - flakstad.kommune.no
     - flatanger.kommune.no
@@ -103,6 +86,7 @@ domains:
     - fyresdal.kommune.no
     - gamvik.kommune.no
     - gausdal.kommune.no
+    - gildeskal.kommune.no
     - giske.kommune.no
     - gjemnes.kommune.no
     - gjerdrum.kommune.no
@@ -117,6 +101,8 @@ domains:
     - grimstad.kommune.no
     - grong.kommune.no
     - grue.kommune.no
+    - gulen.kommune.no
+    - guovdageainnu.suohkan.no
     - ha.kommune.no
     - hadsel.kommune.no
     - haegebostad.kommune.no
@@ -129,6 +115,7 @@ domains:
     - hasvik.kommune.no
     - hattfjelldal.kommune.no
     - haugesund.kommune.no
+    - heim.kommune.no
     - hemnes.kommune.no
     - hemsedal.kommune.no
     - heroy-no.kommune.no
@@ -144,9 +131,12 @@ domains:
     - hoyanger.kommune.no
     - hoylandet.kommune.no
     - hurdal.kommune.no
-    - hvaler.kommune.no
+    - hustadvika.kommune.no
+    - hyllestad.kommune.no
     - ibestad.kommune.no
     - inderoy.kommune.no
+    - indrefosen.kommune.no
+    - io.kommune.no
     - iveland.kommune.no
     - jevnaker.kommune.no
     - jondal.kommune.no
@@ -155,6 +145,7 @@ domains:
     - karlsoy.kommune.no
     - karmoy.kommune.no
     - kautokeino.kommune.no
+    - kinn.kommune.no
     - klepp.kommune.no
     - kongsberg.kommune.no
     - kongsvinger.kommune.no
@@ -175,15 +166,16 @@ domains:
     - lebesby.kommune.no
     - leirfjord.kommune.no
     - leka.kommune.no
-    - lenvik.kommune.no
     - lesja.kommune.no
     - levanger.kommune.no
     - lier.kommune.no
     - lierne.kommune.no
     - lillehammer.kommune.no
     - lillesand.kommune.no
+    - lillestrom.kommune.no
     - lindesnes.kommune.no
     - lodingen.kommune.no
+    - lom.kommune.no
     - loppa.kommune.no
     - lorenskog.kommune.no
     - loten.kommune.no
@@ -201,6 +193,8 @@ domains:
     - melhus.kommune.no
     - meloy.kommune.no
     - meraker.kommune.no
+    - mgk.no
+    - midt-telemark.kommune.no
     - midtre-gauldal.kommune.no
     - modalen.kommune.no
     - modum.kommune.no
@@ -210,8 +204,11 @@ domains:
     - namsos.kommune.no
     - namsskogan.kommune.no
     - nannestad.kommune.no
+    - naroysund.kommune.no
     - narvik.kommune.no
     - nes-ak.kommune.no
+    - nes.kommune.no
+    - nesbyen.kommune.no
     - nesna.kommune.no
     - nesodden.kommune.no
     - nesseby.kommune.no
@@ -238,6 +235,7 @@ domains:
     - oslo.kommune.no
     - osteroy.kommune.no
     - ostre-toten.kommune.no
+    - ototen.no
     - overhalla.kommune.no
     - ovre-eiker.kommune.no
     - oyer.kommune.no
@@ -253,7 +251,6 @@ domains:
     - rauma.kommune.no
     - rendalen.kommune.no
     - rennebu.kommune.no
-    - rennesoy.kommune.no
     - rindal.kommune.no
     - ringebu.kommune.no
     - ringerike.kommune.no
@@ -268,13 +265,16 @@ domains:
     - saltdal.kommune.no
     - samnanger.kommune.no
     - sande-mr.kommune.no
+    - sande.kommune.no
     - sandefjord.kommune.no
     - sandnes.kommune.no
+    - sarpsborg.com
     - sarpsborg.kommune.no
     - sauda.kommune.no
     - sel.kommune.no
     - selbu.kommune.no
     - seljord.kommune.no
+    - senja.kommune.no
     - sigdal.kommune.no
     - siljan.kommune.no
     - sirdal.kommune.no
@@ -311,9 +311,12 @@ domains:
     - stranda.kommune.no
     - stryn.kommune.no
     - sula.kommune.no
+    - suldal.kommune.no
     - sunndal.kommune.no
+    - sunnfjord.kommune.no
     - surnadal.kommune.no
     - sveio.kommune.no
+    - svk.no
     - sykkylven.kommune.no
     - tana.kommune.no
     - time.kommune.no
@@ -333,6 +336,7 @@ domains:
     - tysnes.kommune.no
     - tysver.kommune.no
     - ullensaker.kommune.no
+    - ullensvang.kommune.no
     - ulstein.kommune.no
     - ulvik.kommune.no
     - utsira.kommune.no
@@ -343,6 +347,7 @@ domains:
     - vagsoy.kommune.no
     - vaksdal.kommune.no
     - valer-of.kommune.no
+    - valer.kommune.no
     - valle.kommune.no
     - vang.kommune.no
     - vanylven.kommune.no
@@ -354,6 +359,7 @@ domains:
     - vennesla.kommune.no
     - verdal.kommune.no
     - vestby.kommune.no
+    - vestnes.kommune.no
     - vestre-slidre.kommune.no
     - vestre-toten.kommune.no
     - vestvagoy.kommune.no
@@ -362,4 +368,7 @@ domains:
     - vindafjord.kommune.no
     - vinje.kommune.no
     - volda.kommune.no
+    - voss.herad.no
     - voss.kommune.no
+    - www.hvaler.kommune.no
+    - www.kvam.no


### PR DESCRIPTION
Just a cleanup PR of the Norwegian Municipalities campaign

Main things addressed: 
1. Sorted alphabetically (done by my validator script)
2. Removed some dead domains
   1. rennesoy.kommune.no
   2. envik.kommune.no
   3. finnoy.kommune.no
   4. bjugn.kommune.no
3. Fixed two domains that only reply on www
   1. www.hvaler.kommune.no
   2. www.kvam.no
4. Added some missing domains
   1. For example https://www.sarpsborg.com/