### PR TITLE
feat: expand Norwegian Political Parties.

### DIFF
--- a/Norwegian_Political_Parties.yml
+++ b/Norwegian_Political_Parties.yml
@@ -2,12 +2,36 @@ title: Norwegian Political Parties
 description: Official websites of Norway's key political parties
 uuid: a7b094a0-d82e-448e-9de3-fa734aba73f8
 domains:
+    - alesundlista.no
     - arbeiderpartiet.no
+    - bergenslisten.no
+    - byogbygdelista.no
+    - demokratene.org
+    - folkelistakrs.no
+    - folkets-rost.no
+    - folketsparti.no
     - frp.no
+    - generasjonspartiet.no
+    - granbygdeliste.no
     - hoyre.no
+    - inpartiet.no
+    - itpartiet.no
+    - karmoylista.no
+    - konservativt.no
     - krf.no
+    - liberalistene.org
     - mdg.no
+    - naermiljoelista.no
+    - nkp.no
+    - nordkalottfolket.no
+    - nordmorslista.no
+    - nsr.no
+    - partietsentrum.no
+    - pasientfokus.no
+    - pensjonistpartiet.no
     - roedt.no
+    - samefolketsparti.no
     - senterpartiet.no
+    - sl-bygdeliste.no
     - sv.no
     - venstre.no


### PR DESCRIPTION
One could argue a few of these entries goes against the description "Official websites of Norway's **key** political parties" 

So feel free to remove some. Based it on wikimedia data

For example [Pasientfokus](https://www.stortinget.no/no/Representanter-og-komiteer/Partiene/pasientfokus/) isn't key, but they do have 1 representative. 

Also some are more known and controversial parties, thought they are not "key". But it is in my opinion interesting to track and shame 😂 