### PR TITLE
Add sokkel.io to Norwegian IT Companies list

### DIFF
--- a/Norwegian_IT_Companies.yml
+++ b/Norwegian_IT_Companies.yml
@@ -24,3 +24,4 @@ domains:
     - visma.no
     - bluetree.no
     - conscia.com
+    - sokkel.io


### PR DESCRIPTION
Added `sokkel.io` to the `domains` section in `Norwegian_IT_Companies.yml`.